### PR TITLE
Implement warning and post-clear command hooks

### DIFF
--- a/src/main/java/com/pokeskies/skiesclear/ClearTask.kt
+++ b/src/main/java/com/pokeskies/skiesclear/ClearTask.kt
@@ -49,6 +49,13 @@ class ClearTask(
             }
 
         }
+        if (clearConfig.commands.clear.isNotEmpty()) {
+            for (command in clearConfig.commands.clear) {
+                if (server.commands.performPrefixedCommand(server.createCommandSourceStack(), command) == 0) {
+                    Utils.printError("The post-clearing command \"$command\" failed to execute")
+                }
+            }
+        }
         if (broadcast && (clearConfig.messages.clear.isNotEmpty() || clearConfig.sounds.clear != null)) {
             for (player in server.playerList.players) {
                 for (line in clearConfig.messages.clear) {
@@ -69,6 +76,7 @@ class ClearTask(
                 }
             }
         }
+
         return totalCleared.get()
     }
 
@@ -97,6 +105,14 @@ class ClearTask(
                     warningSound.volume,
                     warningSound.pitch
                 )
+            }
+        }
+        val warningCommands: List<String>? = clearConfig.commands.warnings[timer.toString()]
+        if (warningCommands != null) {
+            for (command in warningCommands) {
+                if (server.commands.performPrefixedCommand(server.createCommandSourceStack(), command) == 0) {
+                    Utils.printError("The ${timer}s warning command \"$command\" failed to execute")
+                }
             }
         }
         if (timer-- <= 0) {

--- a/src/main/java/com/pokeskies/skiesclear/ClearTask.kt
+++ b/src/main/java/com/pokeskies/skiesclear/ClearTask.kt
@@ -53,6 +53,7 @@ class ClearTask(
             for (command in clearConfig.commands.clear) {
                 if (server.commands.performPrefixedCommand(server.createCommandSourceStack(), command) == 0) {
                     Utils.printError("The post-clearing command \"$command\" failed to execute")
+                    break
                 }
             }
         }
@@ -112,6 +113,7 @@ class ClearTask(
             for (command in warningCommands) {
                 if (server.commands.performPrefixedCommand(server.createCommandSourceStack(), command) == 0) {
                     Utils.printError("The ${timer}s warning command \"$command\" failed to execute")
+                    break
                 }
             }
         }

--- a/src/main/java/com/pokeskies/skiesclear/config/ClearConfig.kt
+++ b/src/main/java/com/pokeskies/skiesclear/config/ClearConfig.kt
@@ -14,6 +14,7 @@ class ClearConfig(
     val messages: Messages = Messages(),
     val sounds: Sounds = Sounds(),
     val clearables: Clearables? = null,
+    val commands: Commands = Commands(),
 ) {
     class Messages(
         @JsonAdapter(FlexibleListAdaptorFactory::class)
@@ -53,6 +54,16 @@ class ClearConfig(
     ) {
         override fun toString(): String {
             return "Clearables(items=$items, entities=$entities, cobblemon=$cobblemon)"
+        }
+    }
+
+    class Commands(
+        @JsonAdapter(FlexibleListAdaptorFactory::class)
+        val clear: List<String> = emptyList(),
+        val warnings: Map<String, List<String>> = emptyMap(),
+    ) {
+        override fun toString(): String {
+            return "Commands(clear=$clear, warnings=$warnings)"
         }
     }
 

--- a/src/main/resources/assets/skiesclear/config.json
+++ b/src/main/resources/assets/skiesclear/config.json
@@ -46,6 +46,16 @@
           }
         }
       },
+      "commands": {
+        "clear": [
+        ],
+        "warnings": {
+          "10": [
+          ],
+          "5": [
+          ]
+        }
+      },
       "clearables": {
         "items": {
           "enabled": true,


### PR DESCRIPTION
This should close #1, and it seems to work fine as far as my testing goes.

There are still two questions to resolve before it's truly done though:
* How to document it in the example config. Most commands either do something that might be undesirable or may simply be spammy.
* How to handle command failure. Currently the mod just logs an error, but the way I see it there are three other options
    * Throw and thus stop the server. Likely the safest, since it means that the server will never run only some of the commands, but it will tear down the entire server simply if a selector has no targets.
    * Stop executing this series of commands, still fairly safe since it'll never run commands dependent on previous commands that failed, but may still run initial erroneous ones. This is probably my preferred solution.
    * Stop all command execution until a reload, a middle ground that still keeps the server up but without commands possibly going awry. Not a good solution imo, as commands may just seem to silently stop working.

This would be much easier if Minecraft could tell us the difference between malformed commands, and commands that simply didn't run.